### PR TITLE
Ability to send a raw IRCC code directly to the TV

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,14 @@ bravia.send('Mute');
 // Sends multiple IRCC code signals. Change bravia.delay to alter time between each command sent.
 bravia.send(['Up', 'Down', 'Left', 'Right']);
 ```
+### Send raw IRCC Code
+
+```javascript
+const Bravia = require('bravia');
+
+// Connects to a Bravia TV at 192.168.1.2:80 with the PSK 0000.
+let bravia = new Bravia('192.168.1.2', '80', '0000');
+
+// Send request to set source to HDMI1
+bravia.sendIRCC('AAAAAgAAABoAAABaAw==');
+```

--- a/src/bravia.js
+++ b/src/bravia.js
@@ -129,19 +129,9 @@ class Bravia {
                 return;
               }
 
-              let body = `<?xml version="1.0"?>
-                  <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-                      <s:Body>
-                          <u:X_SendIRCC xmlns:u="urn:schemas-sony-com:service:IRCC:1">
-                              <IRCCCode>${ircc.value}</IRCCCode>
-                          </u:X_SendIRCC>
-                      </s:Body>
-                  </s:Envelope>`;
-
-              this._request({
-                path: '/IRCC',
-                body: body
-              }).then(() => setTimeout(() => resolve(), this.delay), reject);
+              this.sendIRCC(ircc.value)
+                .then(resolve)
+                .catch(reject);
             }, reject);
         } else {
           resolve();
@@ -149,6 +139,24 @@ class Bravia {
       };
 
       next();
+    });
+  }
+
+  sendIRCC(ircc) {
+    return new Promise((resolve, reject) => {
+      let body = `<?xml version="1.0"?>
+                  <s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+                      <s:Body>
+                          <u:X_SendIRCC xmlns:u="urn:schemas-sony-com:service:IRCC:1">
+                              <IRCCCode>${ircc}</IRCCCode>
+                          </u:X_SendIRCC>
+                      </s:Body>
+                  </s:Envelope>`;
+
+      this._request({
+        path: '/IRCC',
+        body: body
+      }).then(() => setTimeout(() => resolve(), this.delay), reject);
     });
   }
 


### PR DESCRIPTION
My Sony W829 TV doesn't return HDMI 1, 2 etc in the `getIRCCCodes` method. But if we send the values found under this file linked below, they work perfectly fine.

This change retains existing functionality while exposing the ability to send these commands directly.

https://github.com/shabunin/cf-sonytv/blob/master/scripts/SonyTV.js