### PR TITLE
Fix/harden logic in discovery process

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ let timeout = 5000;
 Bravia.discover(timeout)
   .then(devices => {
     for (let device in devices) {
-      console.log(device);
+      console.log(devices[device]);
     }
   })
   .catch(error => console.error(error));

--- a/src/bravia.js
+++ b/src/bravia.js
@@ -54,6 +54,9 @@ class Bravia {
                 if (!err) {
                   try {
                     let device = result.root.device[0];
+                    if (!device.serviceList) {  // Not all devices return a serviceList (e.g. Philips Hue gateway responds without serviceList)
+                      return;
+                    }
                     let service = device.serviceList[0].service
                       .find(service => service.serviceType[0] === SSDP_SERVICE_TYPE);
 
@@ -117,7 +120,7 @@ class Bravia {
       if (typeof codes === 'string') {
         codes = [codes];
       }
-      
+
       let index = 0;
       let next = () => {
         if (index < codes.length) {


### PR DESCRIPTION
In my home environment, the Bravia discovery process failed, as my Philips Hue Bridge also responded. However, as the Hue Bridge did not include "device.serviceList", an exception was triggered and nothing was detected.

With this proposed fix, the unexpected Hue response is ignored and the Bravia TV is correctly discovered.